### PR TITLE
Input arg substitution as consts

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -13,6 +13,12 @@
       "commands": [
         "dotnet-fsharplint"
       ]
+    },
+    "fantomas-tool": {
+      "version": "4.7.9",
+      "commands": [
+        "fantomas"
+      ]
     }
   }
 }

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -13,12 +13,6 @@
       "commands": [
         "dotnet-fsharplint"
       ]
-    },
-    "fantomas-tool": {
-      "version": "4.7.9",
-      "commands": [
-        "fantomas"
-      ]
     }
   }
 }

--- a/src/Ast/Ast.fsproj
+++ b/src/Ast/Ast.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <RootNamespace>Fol</RootNamespace>
     </PropertyGroup>

--- a/src/Ast/FolTypes.fs
+++ b/src/Ast/FolTypes.fs
@@ -4,41 +4,43 @@ open System.Collections
 
 module Ident =
     type id = Id of int * string
-    
+
     let private stack = Stack()
-    
+
     type Scope(init, map) =
-        let map = map 
+        let map = map
         let mutable counter = init
+
         member _.Enter(names: string list) =
-            List.fold (fun map name ->
-                counter <- counter + 1
-                Map.add name counter map) map names
-            |> fun newMap ->
-                Scope(counter, newMap)
-            
+            List.fold
+                (fun map name ->
+                    counter <- counter + 1
+                    Map.add name counter map)
+                map
+                names
+            |> fun newMap -> Scope(counter, newMap)
+
         member _.Look(name) =
             Map.tryFind name map
-            |> Option.defaultWith (fun () ->
-                failwith $"Undefined name %s{name}")
-            |> fun value -> Id (value, name)
-            
+            |> Option.defaultWith (fun () -> failwith $"Undefined name %s{name}")
+            |> fun value -> Id(value, name)
+
     let start = Scope(0, Map.empty)
-        
+
 
 type ('a, 'b) Term =
-    | BitwiseMinimum of  Term<'a, 'b> * Term<'a, 'b>
+    | BitwiseMinimum of Term<'a, 'b> * Term<'a, 'b>
     | Plus of Term<'a, 'b> * Term<'a, 'b>
     | Mult of Term<'a, 'b> * Term<'a, 'b> // Left argument can only Const, otherwise we must fail
     | Const of 'b
-    | Var of 'a 
+    | Var of 'a
 
-type  Atom<'a, 'b> =
+type Atom<'a, 'b> =
     | True
     | False
     | Equals of Term<'a, 'b> * Term<'a, 'b>
     | Less of Term<'a, 'b> * Term<'a, 'b>
-    | Greater of Term<'a, 'b> *  Term<'a, 'b>
+    | Greater of Term<'a, 'b> * Term<'a, 'b>
 
 type Literal<'a, 'b> =
     | BareAtom of Atom<'a, 'b>

--- a/src/Ast/FolTypes.fs
+++ b/src/Ast/FolTypes.fs
@@ -1,24 +1,50 @@
 namespace Ast
 
-type Term =
-    | BitwiseMinimum of Term * Term
-    | Plus of Term * Term
-    | Mult of Term * Term // Left argument can only Const, otherwise we must fail
-    | Const of int
-    | Var of string
+open System.Collections
 
-type Atom =
+module Ident =
+    type id = Id of int * string
+    
+    let private stack = Stack()
+    
+    type Scope(init, map) =
+        let map = map 
+        let mutable counter = init
+        member _.Enter(names: string list) =
+            List.fold (fun map name ->
+                counter <- counter + 1
+                Map.add name counter map) map names
+            |> fun newMap ->
+                Scope(counter, newMap)
+            
+        member _.Look(name) =
+            Map.tryFind name map
+            |> Option.defaultWith (fun () ->
+                failwith $"Undefined name %s{name}")
+            |> fun value -> Id (value, name)
+            
+    let start = Scope(0, Map.empty)
+        
+
+type ('a, 'b) Term =
+    | BitwiseMinimum of  Term<'a, 'b> * Term<'a, 'b>
+    | Plus of Term<'a, 'b> * Term<'a, 'b>
+    | Mult of Term<'a, 'b> * Term<'a, 'b> // Left argument can only Const, otherwise we must fail
+    | Const of 'b
+    | Var of 'a 
+
+type  Atom<'a, 'b> =
     | True
     | False
-    | Equals of Term * Term
-    | Less of Term * Term
-    | Greater of Term * Term
+    | Equals of Term<'a, 'b> * Term<'a, 'b>
+    | Less of Term<'a, 'b> * Term<'a, 'b>
+    | Greater of Term<'a, 'b> *  Term<'a, 'b>
 
-type Literal =
-    | BareAtom of Atom
-    | Not of Literal
-    | And of Literal * Literal
-    | Or of Literal * Literal
-    | Implies of Literal * Literal
-    | Exists of string list * Literal
-    | Forall of string list * Literal
+type Literal<'a, 'b> =
+    | BareAtom of Atom<'a, 'b>
+    | Not of Literal<'a, 'b>
+    | And of Literal<'a, 'b> * Literal<'a, 'b>
+    | Or of Literal<'a, 'b> * Literal<'a, 'b>
+    | Implies of Literal<'a, 'b> * Literal<'a, 'b>
+    | Exists of 'a list * Literal<'a, 'b>
+    | Forall of 'a list * Literal<'a, 'b>

--- a/src/DFA/DFA.fs
+++ b/src/DFA/DFA.fs
@@ -41,25 +41,6 @@ type Configuration<'a, 'char when 'char: equality> =
 
 type DFA<'a, 'char when 'char: equality>(startState: State<'a, 'char>) =
 
-    // let allStates, alphabet =
-    //     let allStates = HashSet<_>()
-    //     let alphabet = HashSet<_>()
-    //     let dfs (state:State<_,_>) =
-    //         let visited = HashSet<_>()
-    //         let toProcess = Stack<_> [state]
-    //         while toProcess.Count > 0 do
-    //             let currentState = toProcess.Pop()
-    //             let added = allStates.Add currentState
-    //             assert added
-    //             let added = visited.Add currentState
-    //             assert added
-    //             for (char, targetState) in  currentState.GetAllTransitions() do
-    //                 alphabet.Add char |> ignore
-    //                 if visited.Contains targetState |> not
-    //                 then toProcess.Push targetState
-    //     dfs startState
-    //     allStates, alphabet
-
     let rec step (configuration: Configuration<'a, 'char>) =
         match configuration.RestOfInput with
         | [] ->

--- a/src/DFA/DFA.fsproj
+++ b/src/DFA/DFA.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <RootNamespace>DFA</RootNamespace>
     </PropertyGroup>

--- a/src/DFA/FolToDFA.fs
+++ b/src/DFA/FolToDFA.fs
@@ -3,7 +3,7 @@
 open Ast
 open PeanutProver.Automata
 
-let convertAtom (atom: Atom) =
+let convertAtom atom =
     match atom with
     | Less(left, right) -> PredefinedAutomata.dfa_less
     | Equals(left, right) ->
@@ -19,7 +19,7 @@ let convertAtom (atom: Atom) =
         | e -> failwithf $"Unsupported term {e}"
     | e -> failwithf $"Unsupported atom {e}"
 
-let rec buildProver (ast: Literal) =
+let rec buildProver ast =
     match ast with
     | BareAtom a -> convertAtom a
     | Or(left, right) ->

--- a/src/FolParser/AtomParser.fsi
+++ b/src/FolParser/AtomParser.fsi
@@ -3,4 +3,4 @@ module FolParser.AtomParser
 open FParsec
 open Ast
 
-val parseAtom: (CharStream<unit> -> Reply<Atom>)
+val parseAtom: (CharStream<unit> -> Reply<Atom<_, _>>)

--- a/src/FolParser/FolParser.fsproj
+++ b/src/FolParser/FolParser.fsproj
@@ -1,17 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>
         <Compile Include="CommonParsers.fs"/>
-        <Compile Include="TermParser.fsi"/>
         <Compile Include="TermParser.fs"/>
-        <Compile Include="AtomParser.fsi"/>
         <Compile Include="AtomParser.fs"/>
-        <Compile Include="LiteralParser.fsi"/>
         <Compile Include="LiteralParser.fs"/>
     </ItemGroup>
 

--- a/src/FolParser/LiteralParser.fs
+++ b/src/FolParser/LiteralParser.fs
@@ -5,7 +5,7 @@ open CommonParsers
 open AtomParser
 open Ast
 
-let opp = OperatorPrecedenceParser<Literal, string list, unit>()
+let opp = OperatorPrecedenceParser<Literal<_, _>, string list, unit>()
 let expr = opp.ExpressionParser
 
 let pEmpty = preturn [] .>> ws

--- a/src/FolParser/LiteralParser.fsi
+++ b/src/FolParser/LiteralParser.fsi
@@ -3,4 +3,4 @@ module FolParser.LiteralParser
 open FParsec
 open Ast
 
-val parseLiteral: Parser<Literal, unit>
+val parseLiteral: Parser<Literal<_, _>, unit>

--- a/src/FolParser/TermParser.fs
+++ b/src/FolParser/TermParser.fs
@@ -4,7 +4,7 @@ open FParsec
 open CommonParsers
 open Ast
 
-let opp = OperatorPrecedenceParser<Term, unit, unit>()
+let opp = OperatorPrecedenceParser<Term<_, _>, unit, unit>()
 let expr = opp.ExpressionParser
 
 let term =

--- a/src/FolParser/TermParser.fsi
+++ b/src/FolParser/TermParser.fsi
@@ -3,4 +3,4 @@ module FolParser.TermParser
 open FParsec
 open Ast
 
-val parseTerm: (CharStream<unit> -> Reply<Term>)
+val parseTerm: (CharStream<unit> -> Reply<Term<_, _>>)

--- a/src/PeanutProver.CLI/MainAsync.fs
+++ b/src/PeanutProver.CLI/MainAsync.fs
@@ -11,13 +11,97 @@ open FolParser.LiteralParser
 open PeanutProver.Automata
 open PeanutProver.DFA
 
-type Operation =
-    | Def of string * string list option * Literal
+type Operation<'a, 'b> =
+    | Def of string * string list option * Literal<'a, 'b>
     | Eval of string * string list option
     | Show of string
     | Help
-    | Quit
-
+    | Quit 
+    
+module Names =
+    let assign scope =
+        let rec term (scope: Ident.Scope) expr =
+            let term = term scope in 
+            match   expr with 
+            | BitwiseMinimum (left, right) ->
+                BitwiseMinimum (term left, term right)
+            | Plus (left, right) -> Plus(term left, term right )
+            | Mult (left, right) -> Mult(term left, term right)
+            | Const c -> Const c
+            | Var name -> Var <| scope.Look(name)
+        
+        let rec atom scope expr =
+            match expr with
+            | True -> True
+            | False -> False
+            | Equals  (left, right) ->
+                Equals <| (term scope left, term scope right)
+            | Less (left, right) ->
+                Less  (term scope left, term scope right)
+            | Greater (left, right) ->
+                Greater (term scope left, term scope right)
+                
+        let rec liter (scope: Ident.Scope) lit =
+            let sameScope = liter scope in
+            match lit with 
+            | BareAtom a -> BareAtom <| atom scope a
+            | Not l -> Not <| sameScope l
+            | And (left, right) ->
+                  (sameScope left, sameScope right) |> And
+            | Or (left, right) ->
+                (sameScope left, sameScope right) |> Or
+            | Implies (left, right) ->
+                (sameScope left, sameScope right) |> Implies
+            | Exists (names, next) -> 
+                let newScope = scope.Enter(names) in
+                let names = List.map newScope.Look names in 
+                (names, liter newScope next) |> Exists
+            | Forall (names, next) ->
+                // copypast see above
+                let newScope = scope.Enter(names) in
+                let names = List.map newScope.Look names in 
+                (names, liter newScope next) |> Forall 
+        in
+        liter scope
+        
+    let substituteConstant globals values =
+        let map = List.fold (fun acc (name, value) -> Map.add name value acc) Map.empty <| List.zip globals values  in 
+        let getValue key = Map.tryFind key map |> Option.defaultWith (fun () -> failwith "Undefined global variable") in  
+        let isGlobal name = List.exists ((=) name) globals in 
+        let rec term = function 
+            | BitwiseMinimum (left, right) ->
+                BitwiseMinimum (term left, term right)
+            | Plus (left, right) -> Plus(term left, term right )
+            | Mult (left, right) -> Mult(term left, term right)
+            | Const _ -> failwith "not supported"
+            | Var name -> if isGlobal name then Const <| getValue name else Var name
+        
+        let rec atom = function 
+            | True -> True
+            | False -> False
+            | Equals  (left, right) ->
+                Equals <| (term left, term right)
+            | Less (left, right) ->
+                Less  (term left, term right)
+            | Greater (left, right) ->
+                Greater (term left, term right)
+                
+        let rec liter = function 
+            | BareAtom a -> BareAtom <| atom a
+            | Not l -> Not <| liter l
+            | And (left, right) ->
+                  (liter left, liter right) |> And
+            | Or (left, right) ->
+                (liter left, liter right) |> Or
+            | Implies (left, right) ->
+                (liter left, liter right) |> Implies
+            | Exists (names, next) -> 
+                (names, liter next) |> Exists
+            | Forall (names, next) ->
+                (names, liter next) |> Forall 
+        in
+        liter
+        
 type MainAsync(hostApplicationLifetime: IHostApplicationLifetime) =
     let _help =
         """Available commands:
@@ -30,7 +114,7 @@ type MainAsync(hostApplicationLifetime: IHostApplicationLifetime) =
 
     let _cancellationToken = hostApplicationLifetime.ApplicationStopping
     let mutable _isRunning = true
-    let _automata = Dictionary<string, Literal * DFA<_, _>>()
+    let _automata = Dictionary<string, _>()
 
     let value =
         many1 (many1SatisfyL isDigit "decimal" .>> ws .>> optional (strWs ",")) .>> ws
@@ -54,17 +138,27 @@ type MainAsync(hostApplicationLifetime: IHostApplicationLifetime) =
             // TODO: Cross check bound vars if we use DFA
             // TODO: Should we catch exceptions here at all?
             try
-                let automaton = FolToDFA.buildProver formula
-                _automata[name] <- (formula, automaton)
+               let startScope = vars |> function None ->  Ident.start | Some vars -> Ident.start.Enter(vars) in 
+               
+               let formula = Names.assign startScope formula in 
+               let cont = fun values ->
+                    let formula =
+                        let vars = Option.toList vars |> List.concat in 
+                        let globals = List.map startScope.Look vars in 
+                        formula |> Names.substituteConstant globals values 
+                    in FolToDFA.buildProver formula
+                in 
+                
+                _automata[name] <- (formula, cont)
             with ex ->
                 PromptPlus.WriteLine(ex.Message) |> ignore
 
         | Eval(name, vars) ->
             match _automata.TryGetValue name with
-            | true, (formula, automaton) ->
+            | true, f ->
                 let result =
                     match vars with
-                    | None -> automaton.Recognize []
+                    | None -> (snd f <| []) |> fun x -> x.Recognize
                     | Some vars ->
                         let lsbStrings =
                             vars
@@ -83,7 +177,7 @@ type MainAsync(hostApplicationLifetime: IHostApplicationLifetime) =
                             |> Seq.map Seq.toList
                             |> Seq.toList
 
-                        Seq.toList automatonInput |> automaton.Recognize
+                        Seq.toList automatonInput |> ( snd f) |> fun x -> x.Recognize 
 
                 PromptPlus.WriteLine $"Result of {name}: {result}" |> ignore
             | false, _ -> PromptPlus.WriteLine $"Automaton with name \"{name}\" doesn't exists!" |> ignore

--- a/src/PeanutProver.CLI/MainAsync.fs
+++ b/src/PeanutProver.CLI/MainAsync.fs
@@ -16,92 +16,8 @@ type Operation<'a, 'b> =
     | Eval of string * string list option
     | Show of string
     | Help
-    | Quit 
-    
-module Names =
-    let assign scope =
-        let rec term (scope: Ident.Scope) expr =
-            let term = term scope in 
-            match   expr with 
-            | BitwiseMinimum (left, right) ->
-                BitwiseMinimum (term left, term right)
-            | Plus (left, right) -> Plus(term left, term right )
-            | Mult (left, right) -> Mult(term left, term right)
-            | Const c -> Const c
-            | Var name -> Var <| scope.Look(name)
-        
-        let rec atom scope expr =
-            match expr with
-            | True -> True
-            | False -> False
-            | Equals  (left, right) ->
-                Equals <| (term scope left, term scope right)
-            | Less (left, right) ->
-                Less  (term scope left, term scope right)
-            | Greater (left, right) ->
-                Greater (term scope left, term scope right)
-                
-        let rec liter (scope: Ident.Scope) lit =
-            let sameScope = liter scope in
-            match lit with 
-            | BareAtom a -> BareAtom <| atom scope a
-            | Not l -> Not <| sameScope l
-            | And (left, right) ->
-                  (sameScope left, sameScope right) |> And
-            | Or (left, right) ->
-                (sameScope left, sameScope right) |> Or
-            | Implies (left, right) ->
-                (sameScope left, sameScope right) |> Implies
-            | Exists (names, next) -> 
-                let newScope = scope.Enter(names) in
-                let names = List.map newScope.Look names in 
-                (names, liter newScope next) |> Exists
-            | Forall (names, next) ->
-                // copypast see above
-                let newScope = scope.Enter(names) in
-                let names = List.map newScope.Look names in 
-                (names, liter newScope next) |> Forall 
-        in
-        liter scope
-        
-    let substituteConstant globals values =
-        let map = List.fold (fun acc (name, value) -> Map.add name value acc) Map.empty <| List.zip globals values  in 
-        let getValue key = Map.tryFind key map |> Option.defaultWith (fun () -> failwith "Undefined global variable") in  
-        let isGlobal name = List.exists ((=) name) globals in 
-        let rec term = function 
-            | BitwiseMinimum (left, right) ->
-                BitwiseMinimum (term left, term right)
-            | Plus (left, right) -> Plus(term left, term right )
-            | Mult (left, right) -> Mult(term left, term right)
-            | Const _ -> failwith "not supported"
-            | Var name -> if isGlobal name then Const <| getValue name else Var name
-        
-        let rec atom = function 
-            | True -> True
-            | False -> False
-            | Equals  (left, right) ->
-                Equals <| (term left, term right)
-            | Less (left, right) ->
-                Less  (term left, term right)
-            | Greater (left, right) ->
-                Greater (term left, term right)
-                
-        let rec liter = function 
-            | BareAtom a -> BareAtom <| atom a
-            | Not l -> Not <| liter l
-            | And (left, right) ->
-                  (liter left, liter right) |> And
-            | Or (left, right) ->
-                (liter left, liter right) |> Or
-            | Implies (left, right) ->
-                (liter left, liter right) |> Implies
-            | Exists (names, next) -> 
-                (names, liter next) |> Exists
-            | Forall (names, next) ->
-                (names, liter next) |> Forall 
-        in
-        liter
-        
+    | Quit
+
 type MainAsync(hostApplicationLifetime: IHostApplicationLifetime) =
     let _help =
         """Available commands:
@@ -138,17 +54,26 @@ type MainAsync(hostApplicationLifetime: IHostApplicationLifetime) =
             // TODO: Cross check bound vars if we use DFA
             // TODO: Should we catch exceptions here at all?
             try
-               let startScope = vars |> function None ->  Ident.start | Some vars -> Ident.start.Enter(vars) in 
-               
-               let formula = Names.assign startScope formula in 
-               let cont = fun values ->
-                    let formula =
-                        let vars = Option.toList vars |> List.concat in 
-                        let globals = List.map startScope.Look vars in 
-                        formula |> Names.substituteConstant globals values 
-                    in FolToDFA.buildProver formula
-                in 
-                
+                let startScope =
+                    vars
+                    |> function
+                        | None -> Ident.start
+                        | Some vars -> Ident.start.Enter(vars) in
+
+                let formula = Translate.assign startScope formula in
+
+                let cont =
+                    fun values ->
+                        let formula =
+
+                            let vars = Option.toList vars |> List.concat in
+                            List.iter (printfn "var: %A") vars
+                            List.iter (printfn "val: %A") values
+                            let globals = List.map startScope.Look vars in
+                            formula |> Translate.substituteConstant globals values in
+
+                        FolToDFA.buildProver formula in
+
                 _automata[name] <- (formula, cont)
             with ex ->
                 PromptPlus.WriteLine(ex.Message) |> ignore
@@ -158,7 +83,7 @@ type MainAsync(hostApplicationLifetime: IHostApplicationLifetime) =
             | true, f ->
                 let result =
                     match vars with
-                    | None -> (snd f <| []) |> fun x -> x.Recognize
+                    | None -> (snd f <| []) |> fun x -> x.Recognize []
                     | Some vars ->
                         let lsbStrings =
                             vars
@@ -177,7 +102,7 @@ type MainAsync(hostApplicationLifetime: IHostApplicationLifetime) =
                             |> Seq.map Seq.toList
                             |> Seq.toList
 
-                        Seq.toList automatonInput |> ( snd f) |> fun x -> x.Recognize 
+                        Seq.toList automatonInput |> (snd f) |> (fun x -> x.Recognize [])
 
                 PromptPlus.WriteLine $"Result of {name}: {result}" |> ignore
             | false, _ -> PromptPlus.WriteLine $"Automaton with name \"{name}\" doesn't exists!" |> ignore
@@ -204,11 +129,16 @@ type MainAsync(hostApplicationLifetime: IHostApplicationLifetime) =
         else if String.IsNullOrWhiteSpace input.Value then
             loop ()
         else
-            let parseResult = run (parseInput .>> eof) input.Value
 
-            match parseResult with
-            | Success(operation, _, _) -> doOp operation
-            | Failure(message, _, _) -> PromptPlus.WriteLine(message) |> ignore
+            try
+                let parseResult = run (parseInput .>> eof) input.Value
+
+                match parseResult with
+                | Success(operation, _, _) -> doOp operation
+                | Failure(message, _, _) -> PromptPlus.WriteLine(message) |> ignore
+
+            with e ->
+                printf "Error: %s" e.Message
 
             if input.IsAborted then
                 _isRunning <- false

--- a/src/PeanutProver.CLI/PeanutProver.CLI.fsproj
+++ b/src/PeanutProver.CLI/PeanutProver.CLI.fsproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/PeanutProver.CLI/PeanutProver.CLI.fsproj
+++ b/src/PeanutProver.CLI/PeanutProver.CLI.fsproj
@@ -6,6 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <Compile Include="Translate.fs" />
         <Compile Include="MainAsync.fs"/>
         <Compile Include="Program.fs"/>
     </ItemGroup>

--- a/src/PeanutProver.CLI/Translate.fs
+++ b/src/PeanutProver.CLI/Translate.fs
@@ -1,0 +1,82 @@
+module PeanutProver.CLI.Translate
+
+open Ast
+
+let assign scope =
+    let rec term (scope: Ident.Scope) expr =
+        let term = term scope in
+
+        match expr with
+        | BitwiseMinimum(left, right) -> BitwiseMinimum(term left, term right)
+        | Plus(left, right) -> Plus(term left, term right)
+        | Mult(left, right) -> Mult(term left, term right)
+        | Const c -> Const c
+        | Var name -> Var <| scope.Look(name)
+
+    let rec atom scope expr =
+        match expr with
+        | True -> True
+        | False -> False
+        | Equals(left, right) -> Equals <| (term scope left, term scope right)
+        | Less(left, right) -> Less(term scope left, term scope right)
+        | Greater(left, right) -> Greater(term scope left, term scope right)
+
+    let rec liter (scope: Ident.Scope) lit =
+        let sameScope = liter scope in
+
+        match lit with
+        | BareAtom a -> BareAtom <| atom scope a
+        | Not l -> Not <| sameScope l
+        | And(left, right) -> (sameScope left, sameScope right) |> And
+        | Or(left, right) -> (sameScope left, sameScope right) |> Or
+        | Implies(left, right) -> (sameScope left, sameScope right) |> Implies
+        | Exists(names, next) ->
+            let newScope = scope.Enter(names) in
+            let names = List.map newScope.Look names in
+            (names, liter newScope next) |> Exists
+        | Forall(names, next) ->
+            // copypast see above
+            let newScope = scope.Enter(names) in
+            let names = List.map newScope.Look names in
+            (names, liter newScope next) |> Forall in
+
+    liter scope
+
+let substituteConstant globals values =
+    let map =
+        List.fold (fun acc (name, value) -> Map.add name value acc) Map.empty
+        <| List.zip globals values in
+
+    let getValue key =
+        Map.tryFind key map
+        |> Option.defaultWith (fun () -> failwith "Undefined global variable") in
+
+    let isGlobal name = List.exists ((=) name) globals in
+
+    let rec term =
+        function
+        | BitwiseMinimum(left, right) -> BitwiseMinimum(term left, term right)
+        | Plus(left, right) -> Plus(term left, term right)
+        | Mult(left, right) -> Mult(term left, term right)
+        | Const _ -> failwith "not supported"
+        | Var name -> if isGlobal name then Const <| getValue name else Var name
+
+    let rec atom =
+        function
+        | True -> True
+        | False -> False
+        | Equals(left, right) -> Equals <| (term left, term right)
+        | Less(left, right) -> Less(term left, term right)
+        | Greater(left, right) -> Greater(term left, term right)
+
+    let rec liter =
+        function
+        | BareAtom a -> BareAtom <| atom a
+        | Not l -> Not <| liter l
+        | And(left, right) -> (liter left, liter right) |> And
+        | Or(left, right) -> (liter left, liter right) |> Or
+        | Implies(left, right) -> (liter left, liter right) |> Implies
+        | Exists(names, next) -> (names, liter next) |> Exists
+        | Forall(names, next) -> (names, liter next) |> Forall in
+
+    liter

--- a/tests/DFATests/DFATests.fsproj
+++ b/tests/DFATests/DFATests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
         <GenerateProgramFile>false</GenerateProgramFile>

--- a/tests/FolParserTest/FolParserTest.fsproj
+++ b/tests/FolParserTest/FolParserTest.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
         <GenerateProgramFile>false</GenerateProgramFile>


### PR DESCRIPTION
- Strange error about argument/parameter count mismatch 
- Input arg represented as `Const` in ast. Perhaps not the best solution, but perhaps the simplest
  - So we should support `Const` automaton for argument passing